### PR TITLE
FIX - nuvo image process 가 종료되지 않는 문제

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nuvo_image (0.5.11)
+    nuvo_image (0.5.12)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ brew install automake cmake nasm yasm webp x264 mozjpeg
 ### Gemfile
 
 ```ruby
-gem 'nuvo_image', git: 'https://github.com/crema/nuvo_image', tag: '0.5.11'
+gem 'nuvo_image', git: 'https://github.com/crema/nuvo_image', tag: '0.5.12'
 ```
 
 ## Usage

--- a/lib/nuvo_image.rb
+++ b/lib/nuvo_image.rb
@@ -5,9 +5,8 @@ require 'open3'
 module NuvoImage
   def self.process(&_block)
     process = Process.new
-
     yield process
-
+  ensure
     process.close
   end
 end

--- a/lib/nuvo_image/version.rb
+++ b/lib/nuvo_image/version.rb
@@ -1,3 +1,3 @@
 module NuvoImage
-  VERSION = '0.5.11'.freeze
+  VERSION = '0.5.12'.freeze
 end


### PR DESCRIPTION
#### 원인
- exception 이 발생할 시 `process.close` 가 호출되지 않는다. 이게 호출되지 않으면 내부의 C++ 프로그램은 루프에서 벗어나지 못한다.

#### 수정 내용
- exception 이 발생하더라도 `process.close` 를 호출하도록 한다.

https://app.asana.com/0/75312375888163/1200745643426685/f